### PR TITLE
Fix redis connection string default value

### DIFF
--- a/ospc-bot/ospc/appsettings.json
+++ b/ospc-bot/ospc/appsettings.json
@@ -50,7 +50,7 @@
   },
   "Cache":
   {
-    "RedisConnection": "redis://localhost",
+    "RedisConnection": "localhost",
     "DefaultExpirationMinutes": 60
   }
 }


### PR DESCRIPTION
Old value caused an error during runtime, wasn't caught in tests since there aren't any integration tests yet